### PR TITLE
Bump version to 0.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "airo-models"
-version = "0.0.7"
+version = "0.0.8"
 authors = [
   { name = "Andreas Verleysen", email = "andreas.verleysen@ugent.be" },
   { name = "Victor-Louis De Gusseme", email = "victorlouisdg@gmail.com" },


### PR DESCRIPTION
airo-centrifuge depends on airo-drake 0.0.5 which needs a version 0.0.8 of airo-models